### PR TITLE
feature/feat-manage-transaction-screen

### DIFF
--- a/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/approot/AppRootActivity.kt
+++ b/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/approot/AppRootActivity.kt
@@ -14,8 +14,10 @@ import com.kaylen.pillay.expensetracker.ui.view.dashboard.component.summary.stat
 import com.kaylen.pillay.expensetracker.ui.view.dashboard.event.DashboardScreenEventContract
 import com.kaylen.pillay.expensetracker.ui.view.dashboard.state.DashboardStateModel
 import com.kaylen.pillay.expensetracker.ui.view.dashboard.state.DashboardSummaryItemStateModel
+import com.kaylen.pillay.expensetracker.ui.view.managetransaction.state.ManageTransactionStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.bottomappbar.state.BottomAppBarSharedOptionStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.bottomappbar.state.BottomAppBarSharedStateModel
+import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.fullscreendialog.state.FullScreenDialogSharedStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.topappbar.state.TopAppBarSharedStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.transactionsummary.state.TransactionSummarySharedStateModel
 import kotlinx.collections.immutable.toImmutableList
@@ -103,7 +105,15 @@ class AppRootActivity : ComponentActivity() {
                     )
                 ).toImmutableList()
             )
-        ).toImmutableList()
+        ).toImmutableList(),
+        fullScreenDialog = FullScreenDialogSharedStateModel(
+            topAppBar = TopAppBarSharedStateModel(
+                title = "Expense Tracker",
+                subtitle = "Manage Transaction",
+                navigationIcon = true
+            )
+        ),
+        manageTransactionState = ManageTransactionStateModel()
     )
 
     private val eventContract: DashboardScreenEventContract =

--- a/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/dashboard/DashboardScreen.kt
@@ -22,9 +22,11 @@ import com.kaylen.pillay.expensetracker.ui.view.dashboard.component.summary.stat
 import com.kaylen.pillay.expensetracker.ui.view.dashboard.event.DashboardScreenEventContract
 import com.kaylen.pillay.expensetracker.ui.view.dashboard.state.DashboardStateModel
 import com.kaylen.pillay.expensetracker.ui.view.dashboard.state.DashboardSummaryItemStateModel
+import com.kaylen.pillay.expensetracker.ui.view.managetransaction.ManageTransactionComponent
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.bottomappbar.BottomAppBarSharedComponent
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.bottomappbar.state.BottomAppBarSharedOptionStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.bottomappbar.state.BottomAppBarSharedStateModel
+import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.fullscreendialog.FullScreenDialogSharedComponent
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.topappbar.TopAppBarSharedComponent
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.topappbar.state.TopAppBarSharedStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.transactionsummary.TransactionSummarySharedComponent
@@ -53,6 +55,22 @@ internal fun DashboardScreen(
     eventContract: DashboardScreenEventContract?,
     modifier: Modifier = Modifier
 ) {
+    if (state.fullScreenDialog != null) {
+        FullScreenDialogSharedComponent(
+            state = state.fullScreenDialog
+        ) { contentPadding ->
+            when {
+                state.manageTransactionState != null -> {
+                    ManageTransactionComponent(
+                        state = state.manageTransactionState,
+                        eventContract = null,
+                        modifier = Modifier.padding(contentPadding)
+                    )
+                }
+            }
+        }
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = {

--- a/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/dashboard/state/DashboardStateModel.kt
+++ b/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/dashboard/state/DashboardStateModel.kt
@@ -1,5 +1,6 @@
 package com.kaylen.pillay.expensetracker.ui.view.dashboard.state
 
+import com.kaylen.pillay.expensetracker.ui.view.managetransaction.state.ManageTransactionStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.bottomappbar.state.BottomAppBarSharedStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.fullscreendialog.state.FullScreenDialogSharedStateModel
 import com.kaylen.pillay.expensetracker.ui.view.sharedcomponent.topappbar.state.TopAppBarSharedStateModel
@@ -25,5 +26,6 @@ data class DashboardStateModel(
     val topAppBar: TopAppBarSharedStateModel,
     val bottomAppBar: BottomAppBarSharedStateModel,
     val summaryItems: ImmutableList<DashboardSummaryItemStateModel>,
-    val fullScreenDialog: FullScreenDialogSharedStateModel? = null
+    val fullScreenDialog: FullScreenDialogSharedStateModel? = null,
+    val manageTransactionState: ManageTransactionStateModel? = null
 )

--- a/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/ManageTransactionComponent.kt
+++ b/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/ManageTransactionComponent.kt
@@ -1,0 +1,136 @@
+package com.kaylen.pillay.expensetracker.ui.view.managetransaction
+
+import android.content.res.Configuration
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kaylen.pillay.expensetracker.ui.theme.ExpenseTrackerTheme
+import com.kaylen.pillay.expensetracker.ui.view.managetransaction.event.ManageTransactionEventContract
+import com.kaylen.pillay.expensetracker.ui.view.managetransaction.state.ManageTransactionStateModel
+import com.kaylen.pillay.expensetracker.ui.view.managetransaction.state.ManageTransactionType
+
+/*
+ * Designed and developed by Kaylen Travis Pillay.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Composable
+fun ManageTransactionComponent(
+    state: ManageTransactionStateModel,
+    eventContract: ManageTransactionEventContract?,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.scrollable(
+            state = rememberScrollState(),
+            orientation = Orientation.Vertical
+        ).fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        ManageTransactionTypeContainer(
+            state = state.type,
+            eventContract = eventContract,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+        )
+        HorizontalDivider()
+    }
+}
+
+@Composable
+private fun ManageTransactionTypeContainer(
+    state: ManageTransactionType,
+    eventContract: ManageTransactionEventContract?,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.scrollable(
+            state = rememberScrollState(),
+            orientation = Orientation.Horizontal
+        ),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        ManageTransactionType.entries.forEach { entry ->
+            ManageTransactionTypeChip(
+                isChecked = entry == state,
+                type = entry.name,
+                eventContract = eventContract
+            )
+        }
+    }
+}
+
+@Composable
+private fun ManageTransactionTypeChip(
+    isChecked: Boolean,
+    type: String,
+    eventContract: ManageTransactionEventContract?,
+    modifier: Modifier = Modifier,
+) {
+    FilterChip(
+        onClick = { eventContract?.onTransactionTypeClick(type) },
+        label = {
+            Text(type)
+        },
+        selected = isChecked,
+        leadingIcon = if (isChecked) {
+            {
+                Icon(
+                    imageVector = Icons.Filled.Done,
+                    contentDescription = "Done icon",
+                    modifier = Modifier.size(FilterChipDefaults.IconSize)
+                )
+            }
+        } else {
+            null
+        },
+        modifier = modifier
+    )
+}
+
+private val previewState = ManageTransactionStateModel()
+private val previewEventContract: ManageTransactionEventContract? = null
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+private fun PreviewManageTransactionComponent_Day() {
+    ExpenseTrackerTheme {
+        ManageTransactionComponent(previewState, previewEventContract)
+    }
+}
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PreviewManageTransactionComponent_Night() {
+    ExpenseTrackerTheme {
+        ManageTransactionComponent(previewState, previewEventContract)
+    }
+}

--- a/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/event/ManageTransactionEventContract.kt
+++ b/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/event/ManageTransactionEventContract.kt
@@ -1,0 +1,23 @@
+package com.kaylen.pillay.expensetracker.ui.view.managetransaction.event
+
+/*
+ * Designed and developed by Kaylen Travis Pillay.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface ManageTransactionEventContract {
+
+    fun onTransactionTypeClick(type: String)
+
+}

--- a/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/state/ManageTransactionStateModel.kt
+++ b/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/state/ManageTransactionStateModel.kt
@@ -1,0 +1,21 @@
+package com.kaylen.pillay.expensetracker.ui.view.managetransaction.state
+
+/*
+ * Designed and developed by Kaylen Travis Pillay.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data class ManageTransactionStateModel(
+    val type: ManageTransactionType = ManageTransactionType.Expense,
+)

--- a/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/state/ManageTransactionType.kt
+++ b/app/src/main/java/com/kaylen/pillay/expensetracker/ui/view/managetransaction/state/ManageTransactionType.kt
@@ -1,0 +1,22 @@
+package com.kaylen.pillay.expensetracker.ui.view.managetransaction.state
+
+/*
+ * Designed and developed by Kaylen Travis Pillay.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+enum class ManageTransactionType {
+    Income,
+    Expense
+}


### PR DESCRIPTION
## 📚 **Pull Request Title**:
Manage Transaction Screen initial setup implementation

---

### **Description**:
The initial manage transaction screen has been added. This screen will allow for the user to 
add and edit transactions to their expense tracker account.

---

### **Related Issue(s)**:
Resolves [#19](https://github.com/KaylenTPillay/Expense-Tracker-App/issues/19)

---

### **Changes Made**:
- Added Dashboard Summary event contact
- Added Dashboard Summary hookup
- Added Manage Transaction component, state model and event contract.

---

### **Testing**:
- Tested on physical Android device, Google Pixel 4a

---

### **Checklist**:
- [x] Code follows the project’s coding style.
- [x] All new and existing tests passed.
- [x] Documentation updated, if applicable.
- [x] I have verified that this PR is linked to the relevant issue(s).

---

### **Screenshots**:
N/A

---

### **Notes**:
N/A